### PR TITLE
fixed

### DIFF
--- a/src/emd/rt_propagation_utils.F
+++ b/src/emd/rt_propagation_utils.F
@@ -307,6 +307,8 @@ CONTAINS
       CASE (use_restart_wfn)
          CALL read_mo_set_from_restart(mo_array, atomic_kind_set, qs_kind_set, particle_set, para_env, &
                                        id_nr=id_nr, multiplicity=dft_control%multiplicity, dft_section=dft_section)
+         CALL set_uniform_occupation_mo_array(mo_array, nspin)
+
          DO ispin = 1, nspin
             CALL calculate_density_matrix(mo_array(ispin), p_rmpv(ispin)%matrix)
          END DO
@@ -378,6 +380,7 @@ CONTAINS
             CALL get_rtp(rtp=rtp, mos_old=mos_old, mos_new=mos_new)
             CALL read_rt_mos_from_restart(mo_array, mos_old, atomic_kind_set, qs_kind_set, particle_set, para_env, &
                                           id_nr, dft_control%multiplicity, dft_section)
+            CALL set_uniform_occupation_mo_array(mo_array, nspin)
             DO ispin = 1, nspin
                CALL calculate_density_matrix(mo_array(ispin), &
                                              p_rmpv(ispin)%matrix)
@@ -386,6 +389,32 @@ CONTAINS
       END SELECT
 
    END SUBROUTINE get_restart_wfn
+
+
+! **************************************************************************************************
+!> \brief Set mo_array(ispin)%uniform_occupation after a restart 
+!> \param qs_env ...
+!> \author Guillaume Le Breton (03.23)
+! **************************************************************************************************
+
+   SUBROUTINE set_uniform_occupation_mo_array(mo_array, nspin)
+     
+      TYPE(mo_set_type), DIMENSION(:), POINTER           :: mo_array
+      INTEGER                                            :: ispin, nspin, mo
+      LOGICAL                                            :: is_uniform
+
+      DO ispin = 1, nspin
+         is_uniform = .TRUE.
+         DO mo = 1, mo_array(ispin)%nmo
+            IF (mo_array(ispin)%occupation_numbers(mo) /= 0.0 .AND. &
+            mo_array(ispin)%occupation_numbers(mo) /= 1.0 .AND. & 
+            mo_array(ispin)%occupation_numbers(mo) /= 2.0)  &
+            is_uniform = .FALSE. 
+         END DO
+         mo_array(ispin)%uniform_occupation = is_uniform
+      END DO
+
+   END SUBROUTINE set_uniform_occupation_mo_array
 
 ! **************************************************************************************************
 !> \brief calculates the density from the complex MOs and passes the density to

--- a/src/emd/rt_propagation_utils.F
+++ b/src/emd/rt_propagation_utils.F
@@ -390,26 +390,28 @@ CONTAINS
 
    END SUBROUTINE get_restart_wfn
 
-
 ! **************************************************************************************************
-!> \brief Set mo_array(ispin)%uniform_occupation after a restart 
-!> \param qs_env ...
+!> \brief Set mo_array(ispin)%uniform_occupation after a restart
+!> \param mo_array ...
+!> \param nspin ...
 !> \author Guillaume Le Breton (03.23)
 ! **************************************************************************************************
 
    SUBROUTINE set_uniform_occupation_mo_array(mo_array, nspin)
-     
+
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mo_array
-      INTEGER                                            :: ispin, nspin, mo
+      INTEGER                                            :: nspin
+
+      INTEGER                                            :: ispin, mo
       LOGICAL                                            :: is_uniform
 
       DO ispin = 1, nspin
          is_uniform = .TRUE.
          DO mo = 1, mo_array(ispin)%nmo
             IF (mo_array(ispin)%occupation_numbers(mo) /= 0.0 .AND. &
-            mo_array(ispin)%occupation_numbers(mo) /= 1.0 .AND. & 
-            mo_array(ispin)%occupation_numbers(mo) /= 2.0)  &
-            is_uniform = .FALSE. 
+                mo_array(ispin)%occupation_numbers(mo) /= 1.0 .AND. &
+                mo_array(ispin)%occupation_numbers(mo) /= 2.0) &
+               is_uniform = .FALSE.
          END DO
          mo_array(ispin)%uniform_occupation = is_uniform
       END DO

--- a/src/qs_mo_io.F
+++ b/src/qs_mo_io.F
@@ -397,7 +397,6 @@ CONTAINS
                mo_array(ispin)%lfomo, &
                mo_array(ispin)%nelectron
             WRITE (ires) mo_array(ispin)%eigenvalues(1:nmo), &
-               mo_array(ispin)%uniform_occupation, &
                mo_array(ispin)%occupation_numbers(1:nmo)
          END IF
          IF (PRESENT(rt_mos)) THEN
@@ -666,8 +665,7 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: nset_info, nshell
       INTEGER, DIMENSION(:, :), POINTER                  :: l, nshell_info
       INTEGER, DIMENSION(:, :, :), POINTER               :: nso_info, offset_info
-      LOGICAL                                            :: minbas, natom_match, uniform_occ_read, &
-                                                            use_this
+      LOGICAL                                            :: minbas, natom_match, use_this
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: eig_read, occ_read
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: vecbuffer, vecbuffer_read
       TYPE(cp_logger_type), POINTER                      :: logger
@@ -777,9 +775,8 @@ CONTAINS
                             "The number of MOs on the restart unit is greater than the number of "// &
                             "the allocated MOs. The read MO set will be truncated!")
 
-            READ (rst_unit) eig_read(1:nmo_read), uniform_occ_read, occ_read(1:nmo_read)
+            READ (rst_unit) eig_read(1:nmo_read), occ_read(1:nmo_read)
             mos(ispin)%eigenvalues(1:nmo) = eig_read(1:nmo)
-            mos(ispin)%uniform_occupation = uniform_occ_read
             mos(ispin)%occupation_numbers(1:nmo) = occ_read(1:nmo)
             DEALLOCATE (eig_read, occ_read)
 
@@ -804,7 +801,6 @@ CONTAINS
          CALL para_env%bcast(mos(ispin)%lfomo)
          CALL para_env%bcast(mos(ispin)%nelectron)
          CALL para_env%bcast(mos(ispin)%eigenvalues)
-         CALL para_env%bcast(mos(ispin)%uniform_occupation)
          CALL para_env%bcast(mos(ispin)%occupation_numbers)
 
          IF (PRESENT(rt_mos)) THEN


### PR DESCRIPTION
WARNING: MAY AFFECTS THE RESTART PROCEDURE

Since a previous PR on the 3rd of February ( Linear density delta kick and restart #2543 ), the old restart files cannot be read properly. 
I have removed previous modifications done on the qs_mo_io.F for backward compatibility. 

The mo%uniform_occupation logical is now defined in the RTP part. 

I apologize if you ran into problems with your restart files generated between the 3rd of February and now. 
If it is the case, you can use the code from before this PR regarding the read_mos_restart_low function to load the restart file and write it again using the version of this PR of  write_mo_set_low. 

